### PR TITLE
Change BRK instruction size to 2 bytes

### DIFF
--- a/nes/cpu.go
+++ b/nes/cpu.go
@@ -55,7 +55,7 @@ var instructionModes = [256]byte{
 
 // instructionSizes indicates the size of each instruction in bytes
 var instructionSizes = [256]byte{
-	1, 2, 0, 0, 2, 2, 2, 0, 1, 2, 1, 0, 3, 3, 3, 0,
+	2, 2, 0, 0, 2, 2, 2, 0, 1, 2, 1, 0, 3, 3, 3, 0,
 	2, 2, 0, 0, 2, 2, 2, 0, 1, 3, 1, 0, 3, 3, 3, 0,
 	3, 2, 0, 0, 2, 2, 2, 0, 1, 2, 1, 0, 3, 3, 3, 0,
 	2, 2, 0, 0, 2, 2, 2, 0, 1, 3, 1, 0, 3, 3, 3, 0,


### PR DESCRIPTION
BRK ($00) has a padding byte so it actually takes 2 bytes, instead of 1.

Per http://nesdev.com/the%20%27B%27%20flag%20&%20BRK%20instruction.txt:
> Regardless of what ANY 6502 documentation says, BRK is a 2 byte opcode. The 
first is #$00, and the second is a padding byte. This explains why interrupt 
routines called by BRK always return 2 bytes after the actual BRK opcode, 
and not just 1.

Because of this Your emulator doesn't pass blarrg's "instr_test_v5" (official_only.nes, test 15) from https://wiki.nesdev.com/w/index.php/Emulator_tests. 