### PR TITLE
Update glfw to v3.2 to add Linux/ARM64 support

### DIFF
--- a/ui/director.go
+++ b/ui/director.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fogleman/nes/nes"
 	"github.com/go-gl/gl/v2.1/gl"
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/go-gl/glfw/v3.2/glfw"
 )
 
 type View interface {

--- a/ui/gameview.go
+++ b/ui/gameview.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fogleman/nes/nes"
 	"github.com/go-gl/gl/v2.1/gl"
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/go-gl/glfw/v3.2/glfw"
 )
 
 const padding = 0

--- a/ui/menuview.go
+++ b/ui/menuview.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fogleman/nes/nes"
 	"github.com/go-gl/gl/v2.1/gl"
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/go-gl/glfw/v3.2/glfw"
 )
 
 const (

--- a/ui/run.go
+++ b/ui/run.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 
 	"github.com/go-gl/gl/v2.1/gl"
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/gordonklaus/portaudio"
 )
 

--- a/ui/util.go
+++ b/ui/util.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/fogleman/nes/nes"
 	"github.com/go-gl/gl/v2.1/gl"
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/go-gl/glfw/v3.2/glfw"
 )
 
 var homeDir string


### PR DESCRIPTION
Closes #45 

Updated dependency 'glfw' to v3.2 to run fogleman/nes on Linux/ARM64 platform.

Signed-off-by: odidev <odidev@puresoftware.com>