### PR TITLE
Fix: emulate unimplemented bits of sprite's byte 2

### DIFF
--- a/nes/ppu.go
+++ b/nes/ppu.go
@@ -287,7 +287,11 @@ func (ppu *PPU) writeOAMAddress(value byte) {
 
 // $2004: OAMDATA (read)
 func (ppu *PPU) readOAMData() byte {
-	return ppu.oamData[ppu.oamAddress]
+	data := ppu.oamData[ppu.oamAddress]
+	if (ppu.oamAddress & 0x03) == 0x02 {
+		data = data & 0xE3
+	}
+	return data
 }
 
 // $2004: OAMDATA (write)


### PR DESCRIPTION
Hi @fogleman !

According to the PPU programmer reference, there are unimplemented bits of sprite's byte 2 (see: [reference](https://wiki.nesdev.com/w/index.php/PPU_programmer_reference#Byte_2)).

This PR modifies PPU's code to emulate this behavior. Verified with `oam_stress` ([PPU Tests](https://wiki.nesdev.com/w/index.php/Emulator_tests#PPU_Tests)).