### PR TITLE
APU fix

### DIFF
--- a/nes/apu.go
+++ b/nes/apu.go
@@ -595,6 +595,9 @@ func (t *Triangle) output() byte {
 	if !t.enabled {
 		return 0
 	}
+	if t.timerPeriod < 3 {
+        return 0;
+    }
 	if t.lengthValue == 0 {
 		return 0
 	}

--- a/nes/apu.go
+++ b/nes/apu.go
@@ -596,8 +596,8 @@ func (t *Triangle) output() byte {
 		return 0
 	}
 	if t.timerPeriod < 3 {
-        return 0;
-    }
+		return 0;
+	}
 	if t.lengthValue == 0 {
 		return 0
 	}


### PR DESCRIPTION
Avoid ultrasonic waves to fix some game, this will fix #50, [reference](https://wiki.nesdev.org/w/index.php?title=APU_Triangle).

> Unlike the [pulse](https://wiki.nesdev.org/w/index.php?title=APU_Pulse) channels, the triangle channel supports frequencies up to the maximum frequency the timer will allow, meaning frequencies up to fCPU/32 (about 55.9 kHz for NTSC) are possible - far above the audible range. Some games, e.g. Mega Man 2, "silence" the triangle channel by setting the timer to zero, which produces a popping sound when an audible frequency is resumed, easily heard e.g. in Crash Man's stage. At the expense of accuracy, these can be eliminated in an emulator e.g. by **halting the triangle channel when an ultrasonic frequency is set (a timer value less than 2)**.