### PR TITLE
APU fixs

### DIFF
--- a/nes/apu.go
+++ b/nes/apu.go
@@ -401,7 +401,6 @@ func (p *Pulse) writeControl(value byte) {
 	p.envelopeEnabled = (value>>4)&1 == 0
 	p.envelopePeriod = value & 15
 	p.constantVolume = value & 15
-	p.envelopeStart = true
 }
 
 func (p *Pulse) writeSweep(value byte) {
@@ -596,7 +595,7 @@ func (t *Triangle) output() byte {
 		return 0
 	}
 	if t.timerPeriod < 3 {
-		return 0;
+		return 0
 	}
 	if t.lengthValue == 0 {
 		return 0


### PR DESCRIPTION
Fixed the abnormal tone when Mario failed.
According to the [document](https://wiki.nesdev.org/w/index.php?title=APU_Pulse), writing $4000 and $4004 (`writeControl`)do not need to start envelope, which will cause ***Super Mario Bros*** to make an abnormal tone when the character fails.