### PR TITLE
fix apu frame period initialization

### DIFF
--- a/nes/apu.go
+++ b/nes/apu.go
@@ -65,6 +65,7 @@ func NewAPU(console *Console) *APU {
 	apu.noise.shiftRegister = 1
 	apu.pulse1.channel = 1
 	apu.pulse2.channel = 2
+	apu.framePeriod = 4
 	apu.dmc.cpu = console.CPU
 	return &apu
 }


### PR DESCRIPTION
This PR fixes the sound for some games that do not initialize the frame counter ($4017) before starting to use the APU (like Bomberman)